### PR TITLE
Compare values by their hashes to address those previously compared by reference

### DIFF
--- a/addons/DataBindControls/BindRepeat.gd
+++ b/addons/DataBindControls/BindRepeat.gd
@@ -108,13 +108,17 @@ func detect_changes(new_value: Array = []) -> bool:
 
 func _assign_item(child, item, i):
 	if array_bind && target_property in child:
-		var m = child[target_property]
 		var current_value = child[target_property]
-		if typeof(current_value) != typeof(item) || current_value != item:
+		var new_hash := hash(var_to_str(item))
+		if (
+			!is_same(current_value, item)
+			|| child.get_meta(target_property + "_hash") != new_hash
+		):
 			_detected_change_log.append(
 				"[%s].%s: %s != %s" % [i, target_property, current_value, item]
 			)
 			child[target_property] = item
+			child.set_meta(target_property + "_hash", new_hash)
 
 
 func _notification(what):

--- a/addons/DataBindControls/Binds.gd
+++ b/addons/DataBindControls/Binds.gd
@@ -230,7 +230,11 @@ func detect_changes() -> bool:
 				var parent = get_parent()
 				if parent.is_visible_in_tree() || p == "visible":
 					var value = bt.get_value()
-					if !_equal_approx(parent[p], value):
+					var new_hash := hash(var_to_str(value))
+					if (
+						!_equal_approx(parent[p], value)
+						|| parent.get_meta(p + "_hash") != new_hash
+					):
 						_detected_change_log.append(
 							"%s: %s != %s" % [bt.full_path, parent[p], value]
 						)
@@ -239,6 +243,7 @@ func detect_changes() -> bool:
 						if "caret_column" in parent:
 							cp = parent.caret_column
 						parent[p] = value
+						parent.set_meta(p + "_hash", new_hash)
 						if "caret_column" in parent:
 							parent.caret_column = cp
 	return changes_detected


### PR DESCRIPTION
This allows Dictionaries, Arrays, and Objects used as bindings to update their targets to have their changes detected properly

Uses `hash(var_to_str(value))`.
Rough timing measurements show hashing step takes 1-10us for primitive types, and 1-2ms for larger objects
The performance could be increased by overloading _to_string as that is what's being hashed. There doesn't seem to be a more efficient binary serialization for objects in godot.
Unfortunately, `var_to_bytes_with_objects` doesn't work for inner classes, and `inst_to_dict` doesn't convert nested objects to dicts recursively